### PR TITLE
Trim tasks and allow spaces in Task List

### DIFF
--- a/source/code/handlers/select_resources_handler.py
+++ b/source/code/handlers/select_resources_handler.py
@@ -213,7 +213,7 @@ class SelectResourcesHandler:
 
             if tags_filter is None:
                 # test if name of the task is in list of tasks in tag value
-                if tagname in tags and taskname in tags[tagname].split(","):
+                if tagname in tags and taskname in [x.strip() for x in tags[tagname].split(',')]:
                     self._logger.debug(DEBUG_SELECTED_BY_TASK_NAME_IN_TAG_VALUE, safe_json(resource, indent=2),
                                        tagname, taskname)
                     return True


### PR DESCRIPTION
I got caught out because when the task list has a space after the comma, the task doesn't match. 

eg: `CreateSnapshotDaily, CreateSnapShotHourly` will not match

This PR trims the task string before comparing 
